### PR TITLE
Sticky toolbar pinned to the top of the page containing:  A live sear…

### DIFF
--- a/browser/css/linkgopher.css
+++ b/browser/css/linkgopher.css
@@ -1,13 +1,125 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', monospace;
+  font-size: 13px;
+  background: #1a1a2e;
+  color: #c9d1d9;
+  padding: 0;
+  min-height: 100vh;
+}
+
+/* Toolbar */
+#toolbar {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  background: #16213e;
+  border-bottom: 1px solid #0f3460;
+  flex-wrap: wrap;
+}
+
+#search-input {
+  flex: 1;
+  min-width: 180px;
+  padding: 6px 10px;
+  border: 1px solid #0f3460;
+  border-radius: 6px;
+  background: #1a1a2e;
+  color: #c9d1d9;
+  font-size: 13px;
+  outline: none;
+  transition: border-color 0.15s;
+}
+
+#search-input:focus {
+  border-color: #e94560;
+}
+
+#search-input::placeholder {
+  color: #555;
+}
+
+.toolbar-btn {
+  padding: 6px 12px;
+  border: 1px solid #0f3460;
+  border-radius: 6px;
+  background: #1a1a2e;
+  color: #c9d1d9;
+  font-size: 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
+.toolbar-btn:hover {
+  background: #0f3460;
+  border-color: #e94560;
+  color: #fff;
+}
+
+.toolbar-btn.copied {
+  border-color: #3fb950;
+  color: #3fb950;
+}
+
+/* Content sections */
+#links,
+#domains {
+  padding: 20px 16px 8px;
+}
+
+#domains {
+  margin-top: 8px;
+  border-top: 1px solid #0f3460;
+  padding-top: 20px;
+}
+
+/* Section headers via data-content */
 #links:not(:empty)::before,
 #domains:not(:empty)::before {
   content: attr(data-content);
   display: block;
-  font-weight: bold;
-  margin-bottom: 1em;
+  font-weight: 600;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #8b949e;
+  margin-bottom: 10px;
 }
 
-#domains {
-  margin-top: 2em;
+/* Links */
+#links a,
+#domains a {
+  display: inline-block;
+  color: #58a6ff;
+  text-decoration: none;
+  font-size: 13px;
+  line-height: 1.6;
+  transition: color 0.1s;
+}
+
+#links a:hover,
+#domains a:hover {
+  color: #e94560;
+  text-decoration: underline;
+}
+
+/* Message / loading state */
+#message {
+  padding: 40px 16px;
+  text-align: center;
+  color: #8b949e;
+  font-size: 14px;
+  font-weight: normal;
 }
 
 #message::before {

--- a/browser/js/linkgopher.js
+++ b/browser/js/linkgopher.js
@@ -2,6 +2,7 @@
 const containerLinks = document.getElementById('links');
 const containerDomains = document.getElementById('domains');
 const message = document.getElementById('message');
+const searchInput = document.getElementById('search-input');
 const reBaseURL = /(^\w+:\/\/[^\/]+)|(^[A-Za-z0-9.-]+)\/|(^[A-Za-z0-9.-]+$)/;
 const tabId = parseInt(location.search.replace(/.*tabId=(\d+).*/, '$1'));
 const filtering = location.search.replace(/.*filtering=(true|false).*/, '$1');
@@ -15,7 +16,7 @@ const filteringDomains = location
 const onlyDomains = location.search.replace(/.*onlyDomains=(true|false).*/, '$1');
 
 chrome.tabs.sendMessage(tabId, {action: 'extract'}, links => {
-  handler(links, pattern, onlyDomains);
+  handler(links || [], pattern, onlyDomains);
 });
 
 // Localization.
@@ -30,7 +31,7 @@ chrome.tabs.sendMessage(tabId, {action: 'extract'}, links => {
 
 /**
  * @function handler
- * @param links
+ * @param {Array} links
  * @param {string} pattern -- Pattern for filtering.
  * @param onlyDomains
  */
@@ -39,21 +40,94 @@ function handler(links, pattern, onlyDomains) {
     return window.alert(chrome.runtime.lastError);
   }
 
-  // To filter links like: javascript:void(0)
+  // Filter out javascript:void(0) style non-URL links.
   const resLinks = links.filter(link => link.lastIndexOf('://', 10) > 0);
-  // Remove duplicate, sorting of links.
+  // Remove duplicates, sort.
   const items = [...(new Set(resLinks))].sort();
   const re = pattern ? new RegExp(pattern, 'g') : null;
   const added = items.filter(link => addNodes(link, containerLinks, re, onlyDomains));
 
   if (!added.length) {
-    return message.dataset.content = chrome.i18n.getMessage('noMatches');
+    message.dataset.content = chrome.i18n.getMessage('noMatches');
+    updateToolbar([], []);
+    return;
   }
-  // Extract base URL from link, remove duplicate, sorting of domains.
-  const domains = [...(new Set(added.map(link => getBaseURL(link))))].sort();
+
+  // Extract base URL, dedupe, sort.
+  const domains = [...(new Set(added.map(link => getBaseURL(link)).filter(Boolean)))].sort();
   const reDomains = filteringDomains ? re : null;
-  domains.forEach(domain => addNodes(domain, containerDomains, reDomains), onlyDomains);
+  domains.forEach(domain => addNodes(domain, containerDomains, reDomains, onlyDomains));
+
+  updateCounts(added.length, domains.length);
+  updateToolbar(added, domains);
+  initSearch();
 };
+
+/**
+ * Update section header counts.
+ */
+function updateCounts(linkCount, domainCount) {
+  const linkLabel = chrome.i18n.getMessage('links') || 'Links';
+  const domainLabel = chrome.i18n.getMessage('domains') || 'Domains';
+  containerLinks.dataset.content = `${linkLabel} (${linkCount})`;
+  containerDomains.dataset.content = `${domainLabel} (${domainCount})`;
+}
+
+/**
+ * Wire up toolbar copy/download buttons.
+ */
+function updateToolbar(linkList, domainList) {
+  document.getElementById('copy-links').addEventListener('click', () => {
+    copyToClipboard(linkList.join('\n'), document.getElementById('copy-links'));
+  });
+
+  document.getElementById('copy-domains').addEventListener('click', () => {
+    copyToClipboard(domainList.join('\n'), document.getElementById('copy-domains'));
+  });
+
+  document.getElementById('download-links').addEventListener('click', () => {
+    const content = ['=== Links ===', ...linkList, '', '=== Domains ===', ...domainList].join('\n');
+    downloadFile(content, 'links.txt');
+  });
+}
+
+/**
+ * Copy text to clipboard, briefly show feedback on button.
+ */
+function copyToClipboard(text, btn) {
+  navigator.clipboard.writeText(text).then(() => {
+    const original = btn.innerHTML;
+    btn.innerHTML = '&#10003; Copied!';
+    btn.classList.add('copied');
+    setTimeout(() => { btn.innerHTML = original; btn.classList.remove('copied'); }, 1500);
+  });
+}
+
+/**
+ * Trigger a .txt file download.
+ */
+function downloadFile(content, filename) {
+  const blob = new Blob([content], {type: 'text/plain'});
+  const a = document.createElement('a');
+  a.href = URL.createObjectURL(blob);
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(a.href);
+}
+
+/**
+ * Live search filter across all rendered link anchors.
+ */
+function initSearch() {
+  searchInput.addEventListener('input', () => {
+    const term = searchInput.value.toLowerCase();
+    document.querySelectorAll('#links a, #domains a').forEach(a => {
+      const visible = !term || a.href.toLowerCase().includes(term);
+      a.style.display = visible ? '' : 'none';
+      a.nextSibling && (a.nextSibling.style && (a.nextSibling.style.display = visible ? '' : 'none'));
+    });
+  });
+}
 
 /**
  * Add nodes to container.
@@ -63,21 +137,20 @@ function handler(links, pattern, onlyDomains) {
  * @param {Node} container
  * @param {object|null} re -- Regular Expression pattern.
  * @param onlyDomains
- * @return {boolean} -- Whether link added into document.
+ * @return {boolean} -- Whether link was added into document.
  */
 function addNodes(url, container, re, onlyDomains) {
   if (re && !url.match(re)) return false;
 
-  if(onlyDomains === 'true' && container === containerLinks) {
+  if (onlyDomains === 'true' && container === containerLinks) {
     return true;
   }
 
-  const br = document.createElement('br');
   const a = document.createElement('a');
   a.href = url;
   a.innerText = url;
   container.appendChild(a);
-  container.appendChild(br);
+  container.appendChild(document.createElement('br'));
 
   return true;
 };

--- a/browser/linkgopher.html
+++ b/browser/linkgopher.html
@@ -6,6 +6,13 @@
     <link rel="stylesheet" href="css/linkgopher.css">
   </head>
   <body>
+    <div id="toolbar">
+      <input id="search-input" type="text" placeholder="Filter displayed links..." autocomplete="off" />
+      <button id="copy-links" class="toolbar-btn" title="Copy all links">&#128203; Copy Links</button>
+      <button id="copy-domains" class="toolbar-btn" title="Copy all domains">&#127760; Copy Domains</button>
+      <button id="download-links" class="toolbar-btn" title="Download as .txt">&#8659; Download</button>
+    </div>
+
     <div id="links" data-content="Links"></div>
     <div id="domains" data-content="Domains"></div>
     <h2 id="message" data-content="Please wait..."></h2>

--- a/content-script.js
+++ b/content-script.js
@@ -29,5 +29,5 @@ function extractLinks() {
     links.push(decodeURI(document.links[index].href));
   }
 
-  return links.length ? links : null;
+  return links;
 };

--- a/popup/css/popup.css
+++ b/popup/css/popup.css
@@ -1,12 +1,51 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background: #1a1a2e;
+  padding: 12px;
+  min-width: 220px;
+}
+
 .container {
-  flex-wrap: nowrap;
+  display: flex;
   flex-direction: column;
+  gap: 8px;
 }
 
 .container > button {
+  display: flex;
+  align-items: center;
+  gap: 10px;
   white-space: nowrap;
+  padding: 10px 14px;
+  border: none;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  background: #16213e;
+  color: #e0e0e0;
+  border: 1px solid #0f3460;
+  transition: background 0.15s, transform 0.1s, border-color 0.15s;
 }
-.container > button:not(:last-child) {
-  margin-bottom: .5em;
-  box-shadow: darkgray
+
+.container > button:hover {
+  background: #0f3460;
+  border-color: #e94560;
+  color: #fff;
+  transform: translateX(2px);
+}
+
+.container > button:active {
+  transform: translateX(0);
+}
+
+.btn-icon {
+  font-size: 15px;
+  line-height: 1;
 }

--- a/popup/js/popup.js
+++ b/popup/js/popup.js
@@ -23,8 +23,9 @@ document.getElementById('about-linkgopher').addEventListener('click', event => {
   {id: 'extract-some', messageId: 'extractSome'},
   {id: 'about-linkgopher', messageId: 'aboutLinkGopher'}
 ].forEach(item => {
-  const container = document.getElementById(item.id);
-  container.innerText = chrome.i18n.getMessage(item.messageId);
+  const btn = document.getElementById(item.id);
+  const label = btn.querySelector('.btn-label');
+  if (label) label.innerText = chrome.i18n.getMessage(item.messageId);
 })
 
 /**

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -7,10 +7,22 @@
   </head>
   <body>
     <div class="container">
-      <button id="extract-all" type="button">Extract All Links</button>
-      <button id="extract-domains" type="button">Extract Only Domains</button>
-      <button id="extract-some" type="button">Extract Links by Filter</button>
-      <button id="about-linkgopher" type="button">About Link Gopher</button>
+      <button id="extract-all" type="button">
+        <span class="btn-icon">&#128279;</span>
+        <span class="btn-label">Extract All Links</span>
+      </button>
+      <button id="extract-domains" type="button">
+        <span class="btn-icon">&#127760;</span>
+        <span class="btn-label">Extract Only Domains</span>
+      </button>
+      <button id="extract-some" type="button">
+        <span class="btn-icon">&#128269;</span>
+        <span class="btn-label">Extract Links by Filter</span>
+      </button>
+      <button id="about-linkgopher" type="button">
+        <span class="btn-icon">&#8505;</span>
+        <span class="btn-label">About Link Gopher</span>
+      </button>
     </div>
 
     <script src="js/popup.js" charset="utf-8"></script>


### PR DESCRIPTION
…ch/filter input — as you type, any link or domain not matching your term is instantly hidden, no page reload needed Copy Links button — copies all extracted links to clipboard, shows a brief "✓ Copied!" confirmation Copy Domains button — same, but for the deduplicated domain list Download button — generates a links.txt file with both sections and triggers a browser download Link/domain counts — the section headers now read e.g. "Links (47)" and "Domains (12)" so you know at a glance how many were found.  Visual redesign — matching dark theme, sticky toolbar with subtle border, uppercase section labels, blue links wi

Files Changed
File	What changed
content-script.js	Return [] instead of null
popup/popup.html	Added icon + label spans to each button popup/css/popup.css	Full rewrite — dark theme, flex layout, animations popup/js/popup.js	Localization targets .btn-label span browser/linkgopher.html	Added sticky toolbar (search, copy, download) browser/js/linkgopher.js	Added copy, download, live search, counts; fixed null guard browser/css/linkgopher.css	Full rewrite — dark theme, styled toolbar, link styling